### PR TITLE
Fixed recompression of unchanged exe files, speeding up building exe zip

### DIFF
--- a/src/balamod.rs
+++ b/src/balamod.rs
@@ -187,17 +187,13 @@ fn replace_file_in_exe(exe_path: &str, file_name: &str, new_contents: &[u8]) -> 
         let mut zip_writer = ZipWriter::new(Cursor::new(&mut new_zip));
 
         for i in 0..zip_archive.len() {
-            let mut file = zip_archive.by_index(i)?;
-            if file.name() != file_name {
-                let options = FileOptions::default()
-                    .compression_method(file.compression())
-                    .unix_permissions(file.unix_mode().unwrap_or(0o755));
+            let raw_file = zip_archive.by_index_raw(i)?;
 
-                zip_writer.start_file(file.name(), options)?;
-                let mut file_contents = Vec::new();
-                file.read_to_end(&mut file_contents)?;
-                zip_writer.write_all(&file_contents)?;
+            if raw_file.name() == file_name {
+                continue;
             }
+
+            zip_writer.raw_copy_file(raw_file)?;
         }
 
         zip_writer.start_file(file_name, FileOptions::default().compression_method(CompressionMethod::Stored))?;


### PR DESCRIPTION
Was playing around with similar logic in another repo and realized that there is a function on the file writer, `raw_copy_file`, that lets us write a pre-compressed file in the new zip straight from the reader. This drastically speeds up rebuilding the parts of the zip that are unchanged.

Not sure if you needed the unix perms set on each file, I am using windows so I cant test that. If you did, you could at least use this logic for other platforms.