### PR TITLE
Add nil check before creating directory

### DIFF
--- a/src/luas/mod_core.lua
+++ b/src/luas/mod_core.lua
@@ -366,7 +366,9 @@ function installMod(modId)
 				sendDebugMessage("File " .. filePath .. " already exists")
 			end]] --
 			love.filesystem.write(filePath, body)
-		end
+		else
+            sendDebugMessage("File " .. filePath .. " is in the root directory and will not be installed")
+        end
     end
 
     -- apis first

--- a/src/luas/mod_core.lua
+++ b/src/luas/mod_core.lua
@@ -358,13 +358,15 @@ function installMod(modId)
         local filePath = p:sub(#path + 2)
         sendDebugMessage('Writing to ' .. filePath)
         local dir = filePath:match('(.+)/[^/]+')
-        love.filesystem.createDirectory(dir)
-        --[[if not love.filesystem.getInfo(filePath) then
-            love.filesystem.write(filePath, body)
-        else
-            sendDebugMessage("File " .. filePath .. " already exists")
-        end]] --
-        love.filesystem.write(filePath, body)
+		if dir ~= nil then
+			love.filesystem.createDirectory(dir)
+			--[[if not love.filesystem.getInfo(filePath) then
+				love.filesystem.write(filePath, body)
+			else
+				sendDebugMessage("File " .. filePath .. " already exists")
+			end]] --
+			love.filesystem.write(filePath, body)
+		end
     end
 
     -- apis first


### PR DESCRIPTION
People putting a .gitignore into the repo root would crash balatro when trying to download, cause dir is nil