### PR TITLE
Revert "Custom mods/apis folder and redone the loading of external lua file system to make it more "secure""

### DIFF
--- a/src/luas/mod_core.lua
+++ b/src/luas/mod_core.lua
@@ -17,27 +17,11 @@ if (sendDebugMessage == nil) then
     end
 end
 
-if not rootDir then
-    rootDir = love.filesystem.getSaveDirectory()
-end
-
-if not modsDir then
-    modsDir = love.filesystem.getSaveDirectory() .. "/mods"
-end
-
-if not apiDir then
-    apiDir = love.filesystem.getSaveDirectory() .. "/apis"
-end
-
-if not love.filesystem.getInfo(rootDir, "directory") then
-    love.filesystem.createDirectory(rootDir)
-end
-
-if not love.filesystem.getInfo(modsDir, "directory") then
+if not love.filesystem.getInfo("mods", "directory") then -- Create mods folder if it doesn't exist
     love.filesystem.createDirectory("mods")
 end
 
-if not love.filesystem.getInfo(apiDir, "directory") then
+if not love.filesystem.getInfo("apis", "directory") then -- Create apis folder if it doesn't exist
     love.filesystem.createDirectory("apis")
 end
 
@@ -75,24 +59,6 @@ buildPaths = nil -- prevent rerunning (i think)
 current_game_code = {}
 for _, path in ipairs(paths) do
     current_game_code[path] = love.filesystem.read(path)
-end
-
-function listFiles(directory)
-    local i, t, popen = 0, {}, io.popen
-    local pfile = popen('dir "'..directory..'" /b')
-    for filename in pfile:lines() do
-        i = i + 1
-        t[i] = filename
-    end
-    pfile:close()
-    return t
-end
-
-function fileToString(path)
-    local file = io.open(path, "r")
-    local content = file:read("*all")
-    file:close()
-    return content
 end
 
 function request(url)
@@ -251,55 +217,43 @@ end
 
 -- apis will be loaded first, then mods
 
-local apis_files = listFiles(apiDir)
+local apis_files = love.filesystem.getDirectoryItems("apis") -- Load all apis
 for _, file in ipairs(apis_files) do
-    if file:sub(-4) == ".lua" then
-        local apiPath = apiDir .. "/" .. file
-        local modContent, loadErr = fileToString(apiPath)
+	if file:sub(-4) == ".lua" then -- Only load lua files
+		local modPath = "apis/" .. file
+		local modContent, loadErr = love.filesystem.load(modPath) -- Load the file
 
-        if modContent then
-            local modFunction, err = load(modContent, "@"..apiPath, "t")
-            if modFunction then
-                local success, mod = pcall(modFunction)
-                if success then
-                    table.insert(mods, mod)
-                else
-                    sendDebugMessage("Error running api: " .. apiPath .. "\n" .. tostring(mod))
-                end
-            else
-                sendDebugMessage("Error compiling api: " .. apiPath .. "\n" .. err)
-            end
-        else
-            sendDebugMessage("Error reading api: " .. apiPath .. "\n" .. tostring(loadErr)) -- Log file read errors
-        end
-    end
+		if modContent then -- Check if the file was loaded successfully
+			local success, mod = pcall(modContent)
+			if success then -- Check if the file was executed successfully
+				table.insert(mods, mod) -- Add the api to the list of mods if there is a mod in the file
+			else
+				sendDebugMessage("Error loading api: " .. modPath .. "\n" .. mod) -- Log the error to the console Todo: Log to file
+			end
+		else
+			sendDebugMessage("Error reading api: " .. modPath .. "\n" .. loadErr) -- Log the error to the console Todo: Log to file
+		end
+	end
 end
 
-
-local files = listFiles(modsDir)
+local files = love.filesystem.getDirectoryItems("mods") -- Load all mods
 for _, file in ipairs(files) do
-    if file:sub(-4) == ".lua" then
-        local modPath = modsDir .. "/" .. file
-        local modContent, loadErr = fileToString(modPath)
+	if file:sub(-4) == ".lua" then -- Only load lua files
+		local modPath = "mods/" .. file
+		local modContent, loadErr = love.filesystem.load(modPath) -- Load the file
 
-        if modContent then
-            local modFunction, err = load(modContent, "@"..modPath, "t")
-            if modFunction then
-                local success, mod = pcall(modFunction)
-                if success then
-                    table.insert(mods, mod)
-                else
-                    sendDebugMessage("Error running mod: " .. modPath .. "\n" .. tostring(mod))
-                end
-            else
-                sendDebugMessage("Error compiling mod: " .. modPath .. "\n" .. err)
-            end
-        else
-            sendDebugMessage("Error reading mod: " .. modPath .. "\n" .. tostring(loadErr))
-        end
-    end
+		if modContent then  -- Check if the file was loaded successfully
+			local success, mod = pcall(modContent) -- Execute the file
+			if success then
+				table.insert(mods, mod) -- Add the mod to the list of mods
+			else
+				sendDebugMessage("Error loading mod: " .. modPath .. "\n" .. mod) -- Log the error to the console Todo: Log to file
+			end
+		else
+			sendDebugMessage("Error reading mod: " .. modPath .. "\n" .. loadErr) -- Log the error to the console Todo: Log to file
+		end
+	end
 end
-
 
 for _, mod in ipairs(mods) do
 	if mod.enabled and mod.on_pre_load and type(mod.on_pre_load) == "function" then


### PR DESCRIPTION
This reverts commit f8c604d72e29f3a01e0bd54680474c98f8939310.

On MacOS, this commit causes very weird issues with loading mods. Mod loading works when directly installed from the mod menu, but on a restart, no mods are detected as installed. Furthermore this also hinders the modder's experience with balamod, since you can't load mods from the local folder without going through the marketplace. Lastly, it prevents people from installing mods manually / mods that won't install through the marketplace.

I personnally do not know why this happens.

My guess right know is that using `io` instead of the built-in love filesystem functions break things because of stricter security policies on MacOS (and probably linux, though since there's the proton layer, maybe it's less of an issue ?)